### PR TITLE
Remove unused "primitive"

### DIFF
--- a/lib_gen/bindings.ml
+++ b/lib_gen/bindings.ml
@@ -18,7 +18,6 @@ module Make(F: Cstubs.FOREIGN) = struct
   open F
   open PosixTypes
 
-  external unix_error_of_errno : int -> Unix.error = "unix_error_of_code"
   type dlm_lshandle_t = unit ptr
   let dlm_lshandle_t : dlm_lshandle_t typ = ptr void
   let dlm_lshandle_t_opt : dlm_lshandle_t option typ = ptr_opt void


### PR DESCRIPTION
While testing https://github.com/ocaml/ocaml/pull/10926, I discovered this unused "primitive". There's not enough git history to see what was going on, but this looked highly suspect - `unix_error_of_code` expects a _C_ integer which is tricky to provide from OCaml!

It's unused, so I assume it can be safely deleted.